### PR TITLE
Remove redundant rhcos upload tasks

### DIFF
--- a/tasks/initial_checks.yml
+++ b/tasks/initial_checks.yml
@@ -100,14 +100,3 @@
   fail:
     msg: "Could not find {{ rhcos_image_name }} on OpenStack, nor {{ rhcos_image_file }} locally!"
   when: (openstack_rhcos_image_name == "") and (rhcos_image_file_result['stat']['exists'] != true)
-
-- name: Upload the CoreOS image if it's present locally but not remotelly 
-  os_image:
-    name: rhcos
-    cloud: "{{ openstack_cloud_name }}"
-    state: present
-    container_format: bare
-    disk_format: qcow2
-    filename: "{{ rhcos_image_file }}"
-  when: (openstack_rhcos_image_name == "") and (rhcos_image_file_result['stat']['exists'] == true)
-

--- a/tasks/upload_rhcos_image.yml
+++ b/tasks/upload_rhcos_image.yml
@@ -1,10 +1,12 @@
 ---
-- name: Upload Red Hat CoreOS image to the OpenShift
+
+- name: Upload the CoreOS image if it's present locally but not remotelly 
   os_image:
-    cloud: "{{ openstack_cloud_name }}"
     name: "{{ rhcos_image_name }}"
+    cloud: "{{ openstack_cloud_name }}"
+    state: present
     container_format: bare
     disk_format: qcow2
-    state: present
     filename: "{{ rhcos_image_file }}"
+  when: (openstack_rhcos_image_name == "") and (rhcos_image_file_result['stat']['exists'] == true)
 


### PR DESCRIPTION
Taks "Upload the CoreOS image" seems to be redundantly defined twice. Use only task from the separate playbook