### PR TITLE
Reuse free, not associated FIP. Don't request new one

### DIFF
--- a/tasks/bootstrap_server.yml
+++ b/tasks/bootstrap_server.yml
@@ -26,6 +26,7 @@
 - name: Attach FIP to the bootstrap server
   os_floating_ip:
     state: present
+    reuse: yes
     network: "{{ external_network }}"
     server: "{{ openshift_cluster_id }}-bootstrap"
   when:


### PR DESCRIPTION
Reuse free, not associated FIP instead of requesting a new one. Openstack project usually has a limited amount of FIPs per project