### PR TITLE
Os volume bootable deprecated

### DIFF
--- a/tasks/bootstrap_server.yml
+++ b/tasks/bootstrap_server.yml
@@ -6,7 +6,6 @@
     display_name: "{{ openshift_cluster_id }}-bootstrap-root"
     volume_type: "{{ openstack_boot_volume_type }}"
     image: "{{ rhcos_image_name }}"
-    bootable: yes
 
 - name: Create the bootstrap server
   os_server:

--- a/tasks/control_plane_servers.yml
+++ b/tasks/control_plane_servers.yml
@@ -6,7 +6,6 @@
     display_name: "{{ item.1 }}-{{ item.0 }}-root"
     volume_type: "{{ openstack_boot_volume_type }}"
     image: "{{ rhcos_image_name }}"
-    bootable: yes
   with_indexed_items: "{{ [os_master_server_name] * control_plane_servers }}"
 
 - name: Create control plane ports

--- a/tasks/create_compute_nodes.yml
+++ b/tasks/create_compute_nodes.yml
@@ -28,7 +28,6 @@
     display_name: "{{ item.1 }}-{{ item.0 }}-root"
     volume_type: "{{ openstack_boot_volume_type }}"
     image: "{{ rhcos_image_name }}"
-    bootable: yes
   with_indexed_items: "{{ [os_worker_server_name] * compute_node_servers }}"
 
 - name: Create compute node servers


### PR DESCRIPTION
Ansible os_volume openstack impelementation has deprecated parameter 'bootable'. Remove it.

```
TASK [openshift4-upi-openstack : Create boot volume] *********************************************************************************************************
fatal: [bastion]: FAILED! => changed=false
  msg: 'Unsupported parameters for (os_volume) module: bootable Supported parameters include: api_timeout, auth, auth_type, availability_zone, ca_cert, client_cert, client_key, cloud, display_description, display_name, image, interface, metadata, region_name, scheduler_hints, size, snapshot_id, state, timeout, validate_certs, volume, volume_type, wait
```

openstacksdk used:
```
12:09 $ pip3 list | grep openstacksdk
openstacksdk                   0.52.0
```